### PR TITLE
pristine

### DIFF
--- a/.common.mk
+++ b/.common.mk
@@ -57,3 +57,7 @@ endif
 #   where ... is the argument
 
 maybe_cygwin_path=$(if $(findstring $(OS),Windows_NT),$(shell cygpath -m $(1)),$(1))
+
+# Ensure that any failing rule will not create its target file.
+# In other words, make `make` less insane.
+.DELETE_ON_ERROR:


### PR DESCRIPTION
- **wip, simplify VCs**
- **tactics: Improve error**
- **mk: improving incrementality**
- **Update memory limit in test, use -d instead of -v**
- **Update to new ppxlib**
- **Test OCaml 5.3 in CI**
- **Patch stage0 too**
- **Fix dev-base.Dockerfile**
- **Normalizer: nit in show instance**
- **Fix some incomplete matches**
- **Normalizer: rework norm requests**
- **Fix Nix build**
- **Class.Ord: introduce sort_by**
- **Introduce --stats**
- **Adding a few stats markers**
- **data types a la carte**
- **more a la carte**
- **some proofs**
- **modularizing rewrite rules**
- **SMT: use rlimit and seed as part of query hash**
- **Solver: do not use a hint if its fuels are no longer valid**
- **Makefile: auto-rebuild stage0 when it changes**
- **remove eqtype_as_type from layered effect samples**
- **feat(ulib): add list predicate `for_allP`**
- **An implementation of a naive and hash-based string matcher**
- **wip**
- **Code for PoP in F* chapter on Data types a la carte**
- **an example of a lift in a la carte**
- **Distinguish let-bound tot-terms from others in bind, and do not inline let-bound terms in a VC, rather preserve the naming structure in the VC, to avoid exponential blowup, as in #3800**
- **two proofs need compat:3800. revisit**
- **Several proofs that define local abbreviations expect them to be inlined in VCs---add inline_let annotations**
- **disable a defensive test, for now; TODO revisit this commit**
- **compat:3800 in three files; revisit**
- **strategic inline_let in several examples**
- **Introduce --ext extraction_inline_all**
- **PrettifyType: some tweaks**
- **respect inline_let annotations for inlining behavior in bind**
- **Remove uses of compat:3800**
- **fix a scoping issue revealed by a defensive check in Bug3266**
- **stabilize a couple of proofs; update expected output again**
- **a regression since we no longer capture unit-refinement typing in Tot/GTot continuations**
- **switch to inline_let_vc**
- **support for `let unfold`**
- **replace uses of [@@inline_let_vc] with `let unfold`**
- **better desugaring for let unfold**
- **resugar let unfold**
- **Add --ext optimize_let_vc, enabled for all files in the F* repo**
- **restore handling of unit refinements; fix what seem to be some missing VC closings; more comments; revert `let unfold` in Unit1.Basic---no longer necessary**
- **fix runlim**
- **Makefile: fix stage3-diff to ignore ramon files**
- **Fix sedlex rules**
- **fstar.opam: Fix typo**
- **nix: override sedlex locally to fix version mismatch**
- **DsEnv: use unit values instead of bool for a PSMap used as a set**
- **Improve error**
- **Nit in debug message**
- **Allow native extraction of reifiable effects.**
- **extraction: attempt to extract all type arguments**
- **Bump version number**
- **add `[@@no_inline_let]` annotation for local lets**
- **add test for no_inline_let pragma**
- **Normalizer: simplify identities for real ops (e.g. `1.0R *. x ~> x`)**
- **Makefile: support busybox fin, which does not have -false**
- **F* 2025.06.20**
- **Shuffling some show instances**
- **Allow using `..` to match any number of constructor arguments**
- **Exposing the expansion of `..`, to use from Pulse**
- **CI: restore Nix cache & Nix builds**
- **SMT: printing used rlimit**
- **chore: update nixpkgs, revert sedlex override**
- **fix(nix): make `z3_4_8_5` nix build compatible with darwin plateforms**
- **Debugging nits**
- **Core: fixup use ranges after cache hit**
- **Parser: nit, unify two cases**
- **Syntax: allow writing TC constraints as groups**
- **Parser: simplify, remove always-false boolean**
- **Parser/Lexer: remove unneded argument for some more tokens**
- **Parser: allowing refinements on multibinders**
