### PR TITLE
Reduce GC space_overhead, remove dead param

### DIFF
--- a/src/ml/FStarC_GCSetup.ml
+++ b/src/ml/FStarC_GCSetup.ml
@@ -1,5 +1,1 @@
-let setup () =
-  Gc.set { (Gc.get()) with
-    Gc.minor_heap_size = 1048576;  (* 8 MiB, 4x the default *)
-    Gc.space_overhead = 80;        (* collect more aggressively than the default 120 *)
-  }
+let setup () = ()

--- a/src/ml/FStarC_GCSetup.ml
+++ b/src/ml/FStarC_GCSetup.ml
@@ -1,0 +1,5 @@
+let setup () =
+  Gc.set { (Gc.get()) with
+    Gc.minor_heap_size = 1048576;  (* 8 MiB, 4x the default *)
+    Gc.space_overhead = 80;        (* collect more aggressively than the default 120 *)
+  }

--- a/stage1/dune/main.ml
+++ b/stage1/dune/main.ml
@@ -25,6 +25,6 @@ let x =
       Printexc.record_backtrace true;
 
       (* Tweak garbage collector parameters. *)
-      Gc.set { (Gc.get()) with Gc.minor_heap_size = 1048576; Gc.major_heap_increment = 4194304; Gc.space_overhead = 150; };
+      Fstarcompiler.FStarC_GCSetup.setup ();
 
       Fstarcompiler.FStarC_Main.main ()

--- a/stage1/dune/tests/fstarc1_tests.ml
+++ b/stage1/dune/tests/fstarc1_tests.ml
@@ -25,6 +25,6 @@ let x =
       Printexc.record_backtrace true;
 
       (* Tweak garbage collector parameters. *)
-      Gc.set { (Gc.get()) with Gc.minor_heap_size = 1048576; Gc.major_heap_increment = 4194304; Gc.space_overhead = 150; };
+      Fstarcompiler.FStarC_GCSetup.setup ();
 
       FStarC_Tests_Test.main ()

--- a/stage2/dune/main.ml
+++ b/stage2/dune/main.ml
@@ -25,6 +25,6 @@ let x =
       Printexc.record_backtrace true;
 
       (* Tweak garbage collector parameters. *)
-      Gc.set { (Gc.get()) with Gc.minor_heap_size = 1048576; Gc.major_heap_increment = 4194304; Gc.space_overhead = 150; };
+      Fstarcompiler.FStarC_GCSetup.setup ();
 
       Fstarcompiler.FStarC_Main.main ()

--- a/stage2/dune/tests/fstarc2_tests.ml
+++ b/stage2/dune/tests/fstarc2_tests.ml
@@ -25,6 +25,6 @@ let x =
       Printexc.record_backtrace true;
 
       (* Tweak garbage collector parameters. *)
-      Gc.set { (Gc.get()) with Gc.minor_heap_size = 1048576; Gc.major_heap_increment = 4194304; Gc.space_overhead = 150; };
+      Fstarcompiler.FStarC_GCSetup.setup ();
 
       FStarC_Tests_Test.main ()

--- a/stage3/dune/main.ml
+++ b/stage3/dune/main.ml
@@ -25,7 +25,7 @@ let x =
       Printexc.record_backtrace true;
 
       (* Tweak garbage collector parameters. *)
-      Gc.set { (Gc.get()) with Gc.minor_heap_size = 1048576; Gc.major_heap_increment = 4194304; Gc.space_overhead = 150; };
+      Fstarcompiler.FStarC_GCSetup.setup ();
 
       (* Only on stage3: we've baked Pulse into the compiler, which
          brings in the plugin library. Make sure F* knows this so it

--- a/stage3/dune/tests/fstarc3_tests.ml
+++ b/stage3/dune/tests/fstarc3_tests.ml
@@ -25,6 +25,6 @@ let x =
       Printexc.record_backtrace true;
 
       (* Tweak garbage collector parameters. *)
-      Gc.set { (Gc.get()) with Gc.minor_heap_size = 1048576; Gc.major_heap_increment = 4194304; Gc.space_overhead = 150; };
+      Fstarcompiler.FStarC_GCSetup.setup ();
 
       FStarC_Tests_Test.main ()


### PR DESCRIPTION
The OCaml GC space_overhead parameter controls how much free space is tolerated before a major collection is triggered. The previous value of 150 (meaning 150% of live data as free space) was generous, leading to high peak RSS.

Also, major_heap_increment is completely ignored in OCaml 5, remove it.