### PR TITLE
Don't accumulate full tc_results in batch mode

### DIFF
--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -448,13 +448,8 @@ let go_normal () =
             files, deps, false
           )
         in
-        let tcrs, env, cleanup = Universal.batch_mode_tc fly_deps filenames dep_graph in
+        let module_names, env, cleanup = Universal.batch_mode_tc fly_deps filenames dep_graph in
         ignore (cleanup env);
-        let module_names =
-          tcrs
-          |> List.map (fun tcr ->
-             Universal.module_or_interface_name tcr.checked_module)
-        in
         report_errors module_names;
         finished_message module_names 0
       end //end batch mode

--- a/src/fstar/FStarC.Universal.fst
+++ b/src/fstar/FStarC.Universal.fst
@@ -726,11 +726,11 @@ and tc_one_file_from_remaining
 
 and tc_fold_interleave
       (fly_deps:bool) 
-      (acc:list tc_result &
+      (acc:list (bool & lident) &
            list (uenv & MLSyntax.mlmodule) &  // initial env in which this module is extracted
            uenv)
       (remaining:list string)
-: ML (list Ch.tc_result & list (uenv & MLSyntax.mlmodule) & uenv) =
+: ML (list (bool & lident) & list (uenv & MLSyntax.mlmodule) & uenv) =
   let as_list env mllib =
     match mllib with
     | None -> []
@@ -738,11 +738,12 @@ and tc_fold_interleave
   match remaining with
     | [] -> acc
     | _  ->
-      let mods, mllibs, env_before = acc in
+      let mod_names, mllibs, env_before = acc in
       let remaining, nmod, mllib, env = tc_one_file_from_remaining fly_deps remaining env_before in
       if not (Options.profile_group_by_decl())
       then Profiling.report_and_clear (Ident.string_of_lid nmod.checked_module.name);
-      tc_fold_interleave fly_deps (mods@[nmod], mllibs@(as_list env mllib), env) remaining
+      let mod_name = module_or_interface_name nmod.checked_module in
+      tc_fold_interleave fly_deps (mod_names@[mod_name], mllibs@(as_list env mllib), env) remaining
 
 
 let load_file
@@ -880,7 +881,7 @@ let batch_mode_tc fly_deps filenames dep_graph
       (String.concat " " (filenames |> List.filter Options.should_verify_file))
   end;
   let env = FStarC.Extraction.ML.UEnv.new_uenv (init_env dep_graph) in
-  let all_mods, mllibs, env = tc_fold_interleave fly_deps ([], [], env) filenames in
+  let mod_names, mllibs, env = tc_fold_interleave fly_deps ([], [], env) filenames in
   if FStarC.Errors.get_err_count() = 0 then
     emit dep_graph mllibs;
   let solver_refresh env =
@@ -889,4 +890,4 @@ let batch_mode_tc fly_deps filenames dep_graph
          tcenv.solver.finish();
         (), tcenv)
   in
-  all_mods, env, solver_refresh
+  mod_names, env, solver_refresh

--- a/src/fstar/FStarC.Universal.fsti
+++ b/src/fstar/FStarC.Universal.fsti
@@ -94,4 +94,4 @@ val batch_mode_tc :
     fly_deps:bool ->
     list string ->
     FStarC.Parser.Dep.deps ->
-    ML (list tc_result & uenv & (uenv -> ML uenv))
+    ML (list (bool & lid) & uenv & (uenv -> ML uenv))


### PR DESCRIPTION
batch_mode_tc was accumulating a list of complete tc_result records
(containing full module ASTs + SMT encodings) across all files, but
the only consumer (Main.fst) only extracted module names from them.

Change tc_fold_interleave to accumulate just (bool & lident) module
names instead of full tc_results, allowing the GC to collect the
ASTs after each module is processed.

Benchmarks (1308 matched tests, heavy tests > 100 MiB):
  Memory: median +0.0%, mean -0.5%, range [-21.1%, +11.9%]
  (Impact expected primarily in multi-file batch compilations.)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
