### PR TITLE
Add GC utility FFI bindings (gc_compact, gc_full_major, gc_get_heap_mbs)

### DIFF
--- a/src/basic/FStarC.Util.fsti
+++ b/src/basic/FStarC.Util.fsti
@@ -264,3 +264,8 @@ val create_process : prog:string -> args:(list string) -> ML (*pid:*)int
 val waitpid : pid:int -> ML (either int int) // Inl: exited, Inr: killed by signal
 
 val exn_is_enoent (e:exn) : bool
+
+(* GC utilities for memory optimization *)
+val gc_compact : unit -> ML unit
+val gc_full_major : unit -> ML unit
+val gc_get_heap_mbs : unit -> ML int

--- a/src/ml/FStarC_Util.ml
+++ b/src/ml/FStarC_Util.ml
@@ -931,3 +931,10 @@ let exn_is_enoent (e:exn) : bool =
   match e with
   | Unix.Unix_error (Unix.ENOENT, _, _) -> true
   | _ -> false
+
+(* GC utilities for memory optimization *)
+let gc_compact () = Gc.compact ()
+let gc_full_major () = Gc.full_major ()
+let gc_get_heap_mbs () =
+  let s = Gc.stat () in
+  Z.of_int (int_of_float ((float_of_int (s.Gc.heap_words) *. (float_of_int Sys.word_size /. 8.0)) /. (1024.0 *. 1024.0)))


### PR DESCRIPTION
Add OCaml GC utility functions accessible from F* code:
- gc_compact: trigger heap compaction
- gc_full_major: trigger full major GC cycle
- gc_get_heap_mbs: query current heap size in MB

These are useful for memory debugging and for strategically triggering
GC at module boundaries if needed.

No direct memory impact (tooling only).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
