### PR TITLE
Share memo refs for Tm_delayed nodes to reduce allocations

### DIFF
--- a/src/syntax/FStarC.Syntax.Syntax.fst
+++ b/src/syntax/FStarC.Syntax.Syntax.fst
@@ -213,6 +213,12 @@ let withinfo v r = {v=v; p=r}
 (*********************************************************************************)
 
 (* Constructors for each term form; NO HASH CONSING; just makes all the auxiliary data at each node *)
+(* Shared sentinel refs for Tm_delayed nodes. These nodes are always compressed
+   before Free/Hash analysis, so their vars/hash_code memos are never accessed.
+   Sharing avoids 2 ref allocations per delayed substitution node. *)
+let delayed_vars_ref : ref (option free_vars) = mk_ref None
+let delayed_hash_ref : ref (option FStarC.Hash.hash_code) = mk_ref None
+
 let mk (t:'a) r : ML (syntax 'a) = {
     n=t;
     pos=r;
@@ -264,7 +270,12 @@ let extend_app_n t args' r = match t.n with
     | Tm_app {hd; args} -> mk_Tm_app hd (args@args') r
     | _ -> mk_Tm_app t args' r
 let extend_app t arg r = extend_app_n t [arg] r
-let mk_Tm_delayed lr pos : ML term = mk (Tm_delayed {tm=fst lr; substs=snd lr}) pos
+let mk_Tm_delayed lr pos : ML term = {
+    n = Tm_delayed {tm=fst lr; substs=snd lr};
+    pos = pos;
+    vars = delayed_vars_ref;
+    hash_code = delayed_hash_ref;
+}
 let mk_Total t : ML comp = mk (Total t) t.pos
 let mk_GTotal t : ML comp = mk (GTotal t) t.pos
 


### PR DESCRIPTION
Tm_delayed nodes are always compressed before Free/Hash analysis,
so their vars and hash_code memo fields are never read or written.
Use shared global sentinel refs instead of allocating fresh ref cells,
saving 2 heap allocations per delayed substitution node.

Reduces total minor heap allocations by ~27M words (~200MB) on
the LambdaOmega benchmark.

Benchmarks (1115 matched tests, heavy tests > 100 MiB):
  Memory: median +0.0%, mean -0.1%, range [-20.4%, +10.2%]
  (Reduces allocation pressure rather than peak RSS.)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
