### PR TITLE
Cache basename results in mk_rng to deduplicate file name strings

### DIFF
--- a/src/basic/FStarC.Range.Ops.fsti
+++ b/src/basic/FStarC.Range.Ops.fsti
@@ -38,12 +38,12 @@ val start_of_use_range: range -> pos
 val end_of_use_range: range -> pos
 val line_of_pos: pos -> int
 val col_of_pos: pos -> int
-val end_range: range -> range
+val end_range: range -> ML range
 val compare: range -> range -> int
 val compare_use_range: range -> range -> int
 val range_before_pos : range -> pos -> ML bool
 val end_of_line: pos -> pos
-val extend_to_end_of_line: range -> range
+val extend_to_end_of_line: range -> ML range
 
 val json_of_pos : pos -> Json.json
 val json_of_use_range : range -> Json.json

--- a/src/basic/FStarC.Range.Type.fst
+++ b/src/basic/FStarC.Range.Type.fst
@@ -85,13 +85,22 @@ let mk_pos l c = {
     line=max 0 l;
     col=max 0 c
 }
-let mk_rng file_name start_pos end_pos = {
-    file_name = Filepath.basename file_name;
+(* Cache basename results to avoid recomputing and duplicating strings.
+   The number of distinct input filenames is very small. *)
+let basename_cache : SMap.t string = SMap.create 20
+let cached_basename (s:string) : ML string =
+  match SMap.try_find basename_cache s with
+  | Some r -> r
+  | None -> let r = Filepath.basename s in
+            SMap.add basename_cache s r; r
+
+let mk_rng file_name start_pos end_pos : ML rng = {
+    file_name = cached_basename file_name;
     start_pos = start_pos;
     end_pos   = end_pos
 }
 
-let mk_range f b e = let r = mk_rng f b e in range_of_rng r r
+let mk_range f b e : ML range = let r = mk_rng f b e in range_of_rng r r
 
 open FStarC.Json
 let json_of_pos (r: pos): json

--- a/src/basic/FStarC.Range.Type.fsti
+++ b/src/basic/FStarC.Range.Type.fsti
@@ -43,8 +43,8 @@ val range_of_rng: def_rng:rng -> use_rng:rng -> range
 val set_use_range: range -> rng -> range
 val set_def_range: range -> rng -> range
 val mk_pos: int -> int -> pos
-val mk_rng : string -> pos -> pos -> rng
-val mk_range: string -> pos -> pos -> range
+val mk_rng : string -> pos -> pos -> ML rng
+val mk_range: string -> pos -> pos -> ML range
 
 val json_of_pos: pos -> FStarC.Json.json
 val json_of_rng: rng -> FStarC.Json.json

--- a/src/typechecker/FStarC.TypeChecker.Primops.Range.fst
+++ b/src/typechecker/FStarC.TypeChecker.Primops.Range.fst
@@ -15,11 +15,11 @@ module PC = FStarC.Parser.Const
 (* this type only here to use typeclass hackery *)
 type unsealedRange = | U of Range.t
 
-let mk_range (fn : string) (from_l from_c to_l to_c : int) : Range.t =
+let mk_range (fn : string) (from_l from_c to_l to_c : int) : ML Range.t =
   Range.mk_range fn (mk_pos from_l from_c)
                     (mk_pos to_l   to_c)
 
-let __mk_range (fn : string) (from_l from_c to_l to_c : int) : unsealedRange =
+let __mk_range (fn : string) (from_l from_c to_l to_c : int) : ML unsealedRange =
   U (mk_range fn from_l from_c to_l to_c)
 
 let explode (r : unsealedRange) : (string & int & int & int & int) =
@@ -47,8 +47,12 @@ instance nbe_e_unsealedRange : FStarC.TypeChecker.NBETerm.embedding unsealedRang
     None
 
 let ops = [
-  mk5 0 PC.__mk_range_lid __mk_range;
-  mk5 0 PC.mk_range_lid   mk_range;
+  mk5' 0 PC.__mk_range_lid
+    (fun a b c d e -> Some (__mk_range a b c d e))
+    (fun a b c d e -> Some (__mk_range a b c d e));
+  mk5' 0 PC.mk_range_lid
+    (fun a b c d e -> Some (mk_range a b c d e))
+    (fun a b c d e -> Some (mk_range a b c d e));
   mk1 0 PC.__explode_range_lid explode;
   mk2' 0 PC.join_range_lid
     (fun r1 r2 -> Some (FStarC.Range.union_ranges r1 r2))


### PR DESCRIPTION
mk_rng calls Filepath.basename on every range creation. Since the same
source file names appear in thousands of ranges during typechecking,
this produces many duplicate string allocations.

Add a hashtable cache so that basename is computed once per unique input
and the same string object is reused for all ranges from the same file.
This also avoids the basename recomputation cost.

The change requires mk_rng and mk_range to have ML effect, which
cascades to end_range, extend_to_end_of_line, and the Primops.Range
wrappers.

Benchmarks (1116 matched tests, heavy tests > 100 MiB):
  Memory: median -0.8%, mean -0.9%, range [-20.4%, +1.9%]

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
